### PR TITLE
Revise source tree overview

### DIFF
--- a/SOURCE_TREE_OVERVIEW.md
+++ b/SOURCE_TREE_OVERVIEW.md
@@ -1,0 +1,17 @@
+# Source Tree Overview
+
+This repository contains the 4.4BSD-Lite2 sources as released by the University of California, Berkeley. The following summary lists the major top-level directories and their purpose.
+
+## Top-level directories
+
+- `bin/`, `sbin/`, `usr.bin/`, `usr.sbin/` – user and system utilities
+- `lib/`, `libexec/`, `games/`, `share/` – libraries, daemons, games and shared data
+- `sys/` – kernel sources
+- `etc/`, `dev/`, `root/` – system configuration, device files and root account files
+- `usr/` – userland programs and manual pages
+- `var/` – runtime data
+- `Domestic/` and `Foreign/` – cryptographic software separated due to export regulations of the time
+
+## Using this source tree
+
+These directories form the complete 4.4BSD-Lite2 distribution. They can be built using the makefiles provided in the tree or repurposed for porting and reference.


### PR DESCRIPTION
## Summary
- remove references to Minix/NetBSD from source tree overview
- describe key directories of the 4.4BSD-Lite2 tree instead

## Testing
- `git status --short`
