### PR TITLE
Add modernization helper scripts and outline

### DIFF
--- a/docs/modernization_plan.md
+++ b/docs/modernization_plan.md
@@ -1,0 +1,36 @@
+# Modernization Plan
+
+This document outlines initial steps toward analyzing and updating the 4.4BSD-Lite2
+codebase. It does not constitute a complete refactor, but provides guidance for
+future work.
+
+## Phase 1: Codebase Analysis
+- Generate cross-reference databases using `cscope` and `ctags`.
+- Use `tools/analyze_codebase.py` to count source files by extension.
+- Document architectural assumptions found in headers and assembly files.
+
+## Phase 2: Infrastructure Updates
+- Configure modern compilers (e.g., GCC or Clang) with `-std=c2x`.
+- Maintain compatibility with existing BSD makefiles while introducing
+  modern build options.
+- Integrate static analysis tools such as `clang-tidy`.
+
+## Phase 3: Userland Modernization
+- Update core libraries (`libc`, `libm`) to use ANSI C prototypes.
+- Replace unsafe string functions with bounded equivalents.
+- Introduce incremental tests for updated utilities.
+
+## Phase 4: Kernel Abstraction
+- Define a hardware abstraction layer to encapsulate architecture-specific
+  operations.
+- Begin refactoring scheduler and memory management code to use the HAL.
+
+## Phase 5: Device Driver Migration
+- Categorize drivers by interface type and update them to use the HAL.
+
+## Phase 6: Integration and Validation
+- Establish continuous integration builds for i686 and x86_64 targets.
+- Track regression tests and performance benchmarks.
+
+This plan is a starting point and will require significant effort to achieve a
+fully modernized system.

--- a/tools/analyze_codebase.py
+++ b/tools/analyze_codebase.py
@@ -1,0 +1,26 @@
+import os
+import sys
+from collections import defaultdict
+
+EXTENSIONS = ['.c', '.h', '.s', '.y', '.l', '.sh', '.f']
+
+
+def collect_counts(base_dir):
+    counts = defaultdict(int)
+    for root, dirs, files in os.walk(base_dir):
+        for f in files:
+            _, ext = os.path.splitext(f)
+            if ext in EXTENSIONS:
+                counts[ext] += 1
+    return counts
+
+
+def main():
+    base = sys.argv[1] if len(sys.argv) > 1 else '.'
+    counts = collect_counts(base)
+    for ext in sorted(EXTENSIONS):
+        print(f"{ext}: {counts[ext]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/generate_cscope.sh
+++ b/tools/generate_cscope.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Generate cscope.files for the source tree
+find usr/src sys -name '*.[chsyl]' > cscope.files
+cscope -b -q -k

--- a/tools/generate_ctags.sh
+++ b/tools/generate_ctags.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Generate tags for the source tree
+ctags -R usr/src sys


### PR DESCRIPTION
## Summary
- add codebase analysis script for file counts
- add helper scripts to generate cscope and ctags databases
- document a modernization plan for future work

## Testing
- `python3 tools/analyze_codebase.py | head`
- `sh tools/generate_cscope.sh`
- `sh tools/generate_ctags.sh`
