### PR TITLE
Add C23 build support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  gcc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install GCC
+        run: sudo apt-get update && sudo apt-get install -y build-essential
+      - name: Build with GCC C23
+        run: make -C usr/src CC=gcc CSTD=-std=c2x
+  clang:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Clang
+        run: sudo apt-get update && sudo apt-get install -y clang make
+      - name: Build with Clang C23
+        run: make -C usr/src CC=clang CSTD=-std=c2x

--- a/docs/file_tree.txt
+++ b/docs/file_tree.txt
@@ -1,0 +1,29 @@
+.
+.git
+  branches
+  hooks
+  info
+  logs
+  objects
+  refs
+Domestic
+  src
+Foreign
+  src
+dev
+docs
+etc
+  kerberosIV
+  mtree
+  namedb
+root
+tools
+usr
+  bin
+  lib
+  share
+  src
+  ucb
+var
+  log
+  run

--- a/docs/refactor_c23_tasks.md
+++ b/docs/refactor_c23_tasks.md
@@ -1,0 +1,89 @@
+# C23 and Modern Assembly Refactor Scoping
+
+This document captures initial observations of the repository layout, environment details, and a high level plan for refactoring the 4.4BSD-Lite2 sources to conform to the C23 standard and employ modern assembly practices where applicable.
+
+## Environment
+
+- Kernel: `Linux 6.12.13 x86_64`
+- GCC version: `gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0`
+- Clang version: `clang version 17.0.0 (https://github.com/swiftlang/llvm-project.git 901f89886dcd5d1eaf07c8504d58c90f37b0cfdf)`
+
+These compilers support the upcoming C23 (C2x) standard and provide modern toolchains for assembly generation.
+
+## Repository Overview
+
+A summary of the top level directories is provided by `docs/file_tree.txt`.
+
+```
+.
+.git
+  branches
+  hooks
+  info
+  logs
+  objects
+  refs
+Domestic
+  src
+Foreign
+  src
+dev
+docs
+etc
+  kerberosIV
+  mtree
+  namedb
+root
+tools
+usr
+  bin
+  lib
+  share
+  src
+  ucb
+var
+  log
+  run
+```
+
+## Proposed Agent Tasks
+
+1. **Codebase Enumeration**
+   - Run `tools/analyze_codebase.py` to obtain counts of source files by extension.
+   - Generate cross references using `tools/generate_cscope.sh` and `tools/generate_ctags.sh`.
+   - Document any existing assembly files (`.s`) and identify their architecture dependencies.
+
+2. **Build System Modernization**
+   - Update makefiles to accept `CC=c23` style flags while preserving historical builds.
+   - Introduce CI scripts targeting GCC and Clang with `-std=c2x`.
+   - Record build warnings for later remediation.
+
+3. **API Updates**
+   - Gradually adopt C23 features (e.g., standard attributes, `_Static_assert` usage) in the libc and kernel headers.
+   - Replace legacy types and macros with modern equivalents.
+
+4. **Assembly Review**
+   - For each architecture directory under `sys/` and `usr/src`, note any inline or external assembly.
+   - Evaluate portability of the code and consider rewriting small routines in intrinsics or modern assembly syntax (e.g., GNU `asm`).
+
+5. **File-by-File Refactor**
+   - Prioritize userland utilities in `usr/` for initial conversion.
+   - Develop automated scripts to apply consistent formatting and header updates.
+   - Introduce small unit tests wherever feasible.
+
+6. **Documentation**
+   - Keep this document updated with progress notes and decisions.
+   - Reference coding standards and style guidelines as the project evolves.
+
+This roadmap is intentionally high level. Full conversion of the 4.4BSD-Lite2 tree to C23 will require significant long-term effort and careful testing. The above tasks serve as an initial direction for agents working on the modernization.
+
+## Recent Progress
+
+- Added a `CSTD` variable to `share/mk/sys.mk` so builds can pass `CSTD=-std=c2x`.
+- Introduced a fallback definition of `_Static_assert` in `sys/sys/cdefs.h` to
+  allow compile-time checks on pre-C11 compilers.
+- Created a workflow in `.github/workflows/build.yml` to build the tree with
+  both GCC and Clang using the C23 standard flag.
+- New script `tools/build_collect_warnings.sh` builds the tree and captures
+  compiler warnings for later cleanup.
+

--- a/tools/build_collect_warnings.sh
+++ b/tools/build_collect_warnings.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Build userland with optional CSTD flag and store warnings.
+set -e
+LOGDIR="build_logs"
+mkdir -p "$LOGDIR"
+make -C usr/src CC="${CC:-cc}" CSTD="${CSTD:--std=c2x}" 2>&1 | tee "$LOGDIR/build.log"

--- a/usr/src/share/mk/sys.mk
+++ b/usr/src/share/mk/sys.mk
@@ -13,12 +13,15 @@ RANLIB		?=	ranlib
 AS		?=	as
 AFLAGS		?=
 
-CC		?=	gcc
+CC              ?=      gcc
+
+# Optional C standard flag (e.g., -std=c2x for C23)
+CSTD            ?=
 
 .if ${MACHINE} == "sparc"
-CFLAGS		?=	-O4
+CFLAGS          ?=      -O4 ${CSTD}
 .else
-CFLAGS		?=	-O2
+CFLAGS          ?=      -O2 ${CSTD}
 .endif
 
 CPP		?=	cpp

--- a/usr/src/sys/sys/cdefs.h
+++ b/usr/src/sys/sys/cdefs.h
@@ -118,6 +118,15 @@
 #ifndef __dead
 #define	__dead
 #define	__pure
+/*
+ * Provide a fallback for the C11 `_Static_assert` keyword so headers can
+ * use compile-time checks even when compiled with older C dialects.
+ */
+#ifndef _Static_assert
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ < 201112L
+#define _Static_assert(expr, msg) typedef char __static_assert_t[(expr) ? 1 : -1]
+#endif
+#endif
 #endif
 
 #endif /* !_CDEFS_H_ */


### PR DESCRIPTION
## Summary
- update make infrastructure with `CSTD` flag
- define `_Static_assert` fallback for pre-C11 compilers
- add script and workflow for capturing build warnings
- document latest progress on refactoring

## Testing
- `python3 tools/analyze_codebase.py`
